### PR TITLE
General Cleanup and "fuck you" fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ end
 * `PREPARE YOURSELF <text>` - Generates GoT
 * `WHAT IF I TOLD YOU <text>` - Generates Morpheus
 * `<text> BETTER DRINK MY OWN PISS` - Generates Bear Grylls
-* '<text> wow' - Generates Doge
-* 'Imma let you finish <text>' - Generates Kanye West
+* `(so|very|much|such) <text> wow` - Generates Doge
+* `Imma let you finish <text>` - Generates Kanye West
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ end
 * `PREPARE YOURSELF <text>` - Generates GoT
 * `WHAT IF I TOLD YOU <text>` - Generates Morpheus
 * `<text> BETTER DRINK MY OWN PISS` - Generates Bear Grylls
-* `(so|very|much|such) <text> wow` - Generates Doge
+* `(so|very|much|such) <text> (so|very|much|such) <text> wow` - Generates Doge
 * `Imma let you finish <text>` - Generates Kanye West
 
 ## License

--- a/lib/lita/handlers/memegen.rb
+++ b/lib/lita/handlers/memegen.rb
@@ -123,7 +123,7 @@ module Lita
         shouty_phrase = phrase.upcase
         last_vowel_index = shouty_phrase.rindex(/[AEIOU]/) || -1 # default to final consonant
         last_vowel = shouty_phrase[last_vowel_index]
-        "#{shouty_phrase[0..last_vowel_index]}#{10.times.map{ last_vowel }.join}#{shouty_phrase[last_vowel_index..-1]}!!!!"
+        "#{shouty_phrase[0..last_vowel_index]}#{last_vowel * 10}#{shouty_phrase[last_vowel_index..-1]}!!!!"
       end
 
       def meme_doge(response)

--- a/lib/lita/handlers/memegen.rb
+++ b/lib/lita/handlers/memegen.rb
@@ -139,7 +139,7 @@ module Lita
       private
 
       def generate_meme *args
-        MemeGenerator.generate_meme *args
+        MemeGenerator.generate_meme(*args)
       end
     end
 

--- a/lib/lita/handlers/memegen.rb
+++ b/lib/lita/handlers/memegen.rb
@@ -10,26 +10,26 @@ module Lita
         config.password = nil
       end
 
-      route %r{(Y U NO) (.+)}i,                                    :meme_y_u_no,           help: { "Y U NO..." => "generates Y U NO meme"}
-      route %r{(I DON'?T ALWAYS .*) (BUT WHEN I DO,? .*)}i,        :meme_i_dont_always,    help: { "I DON'T ALWAYS .. BUT WHEN I DO, .." => "generates I DON'T ALWAY meme"}
-      route %r{(.*)(O\s?RLY\??.*)}i,                               :meme_orly,             help: { "..O RLY.." => "generates O RLY meme" }
-      route %r{(.*)(SUCCESS|NAILED IT.*)},                         :meme_success,          help: { "..SUCCESS.." => "(case sensitive) generates SUCCESS meme", "..NAILED IT.." => "generates NAILED IT meme" }
-      route %r{(.*) (ALL the .*)},                                 :meme_all_the,          help: { "ALL the.." => "(case sensitive) generates ALL the <things> meme" }
-      route %r{(.*) (\w+\sTOO DAMN .*)}i,                          :meme_too_damn,         help: { "TOO DAMN.." => "generates TOO DAMN meme" }
-      route %r{(GOOD NEWS EVERYONE[,.!]?) (.*)}i,                  :meme_good_news,        help: { "GOOD NEWS EVERYONE.." => "generates GOOD NEWS EVERYONE meme" }
-      route %r{(NOT SURE IF .*) (OR .*)}i,                         :meme_not_sure_if,      help: { "NOT SURE IF.. OR.." => "generates NOT SURE IF .. OR meme" }
-      route %r{(YO DAWG .*) (SO .*)}i,                             :meme_yo_dawg,          help: { "YO DAWG.." => "generates YO DAWG meme" }
-      route %r{(ALL YOUR .*) (ARE BELONG TO US)}i,                 :meme_are_belong,       help: { "ALL YOUR.. ARE BELONG TO US" => "generates ALL YOUR.. ARE BELONG TO US meme" }
-      route %r{(.*) (FUCK YOU)}i,                                  :meme_fuck_you,         help: { "..FUCK YOU" => "generates ..FUCK YOU meme" }
-      route %r{(.*) (You'?re gonna have a bad time)}i,             :meme_bad_time,         help: { ".. You're going have a bad time" => "generates You're gonna have a bad time meme" }
-      route %r{(one does not simply) (.*)}i,                       :meme_simply,           help: { "one does not simply.." => "generates one does not simply.. meme" }
-      route %r{(grumpy cat) (.*),(.*)}i,                           :meme_grumpy_cat,       help: { "grumpy cat .. , .." => "generates grumpy cat .. , .. meme" }
-      route %r{(it looks like you'?re|it looks like you) (.*)}i,    :meme_looks_like,       help: { "it looks like you're .." => "generates it looks like you're .. meme", "it looks like you.." => "(case insensitive) generates it looks like you.. meme" }
-      route %r{(AM I THE ONLY ONE AROUND HERE) (.*)}i,             :meme_am_i_only,        help: { "AM I THE ONLY ONE AROUND HERE.." => "generates AM I THE ONLY ONE AROUND HERE.. meme" }
-      route %r{(.*)(NOT IMPRESSED*)}i,                             :meme_not_impressed,    help: { "..NOT IMPRESSED" => "generates ..NOT IMPRESSED meme" }
-      route %r{(PREPARE YOURSELF) (.*)}i,                          :meme_prepare_yourself, help: { "PREPARE YOURSELF.." => "generates PREPARE YOURSELF.. meme" }
-      route %r{(WHAT IF I TOLD YOU) (.*)}i,                        :meme_what_if_i,        help: { "WHAT IF I TOLD YOU.." => "generates WHAT IF I TOLD YOU.. meme" }
-      route %r{(.*) (BETTER DRINK MY OWN PISS)}i,                  :meme_better_drink,     help: { "..BETTER DRINK MY OWN PISS" => "generates ..BETTER DRINK MY OWN PISS meme" }
+      route %r{(y u no) (.+)}i,                                    :meme_y_u_no,           help: { "y u no..." => "generates Y U NO meme"}
+      route %r{(i don'?t always .*) (but when i do,? .*)}i,        :meme_i_dont_always,    help: { "i don't always... but when i do,..." => "generates I DON'T ALWAYS meme"}
+      route %r{(.*)(o\s?rly\??.*)}i,                               :meme_orly,             help: { "...o rly..." => "generates O RLY meme" }
+      route %r{(.*)(SUCCESS|NAILED IT.*)},                         :meme_success,          help: { "...SUCCESS" => "(case sensitive) generates SUCCESS meme", "...NAILED IT..." => "(case sensitive) generates NAILED IT meme" }
+      route %r{(.*) (ALL the .*)},                                 :meme_all_the,          help: { "...ALL the..." => "(case sensitive) generates ALL the <things> meme" }
+      route %r{(.*) (\w+\stoo damn .*)}i,                          :meme_too_damn,         help: { "...too damn..." => "generates TOO DAMN meme" }
+      route %r{(good news everyone[,.!]?) (.*)}i,                  :meme_good_news,        help: { "good news everyone..." => "generates GOOD NEWS EVERYONE meme" }
+      route %r{(not sure if .*) (or .*)}i,                         :meme_not_sure_if,      help: { "not sure if... or..." => "generates NOT SURE IF... OR meme" }
+      route %r{(yo dawg .*) (so .*)}i,                             :meme_yo_dawg,          help: { "yo dawg... so..." => "generates YO DAWG meme" }
+      route %r{(all your .*) (are belong to us)}i,                 :meme_are_belong,       help: { "all your... are belong to us" => "generates ALL YOUR... ARE BELONG TO US meme" }
+      route %r{(.*) (fuck you)}i,                                  :meme_fuck_you,         help: { "...fuck you" => "generates ...FUCK YOU meme" }
+      route %r{(.*) (you'?re gonna have a bad time)}i,             :meme_bad_time,         help: { "...you're going have a bad time" => "generates You're gonna have a bad time meme" }
+      route %r{(one does not simply) (.*)}i,                       :meme_simply,           help: { "one does not simply..." => "generates one does not simply... meme" }
+      route %r{(grumpy cat) (.*),(.*)}i,                           :meme_grumpy_cat,       help: { "grumpy cat... ,..." => "generates grumpy cat... ,... meme" }
+      route %r{(it looks like you'?re|it looks like you) (.*)}i,   :meme_looks_like,       help: { "it looks like you're..." => "generates it looks like you're... meme", "it looks like you..." => "(case insensitive) generates it looks like you.. meme" }
+      route %r{(am i the only one around here) (.*)}i,             :meme_am_i_only,        help: { "am I the only one around here..." => "generates AM I THE ONLY ONE AROUND HERE... meme" }
+      route %r{(.*)(not impressed*)}i,                             :meme_not_impressed,    help: { "...not impressed" => "generates ...NOT IMPRESSED meme" }
+      route %r{(prepare yourself) (.*)}i,                          :meme_prepare_yourself, help: { "prepare yourself..." => "generates PREPARE YOURSELF... meme" }
+      route %r{(what if i told you) (.*)}i,                        :meme_what_if_i,        help: { "what if I told you..." => "generates WHAT IF I TOLD YOU... meme" }
+      route %r{(.*) (better drink my own piss)}i,                  :meme_better_drink,     help: { "..better drink my own piss" => "generates ...BETTER DRINK MY OWN PISS meme" }
       route %r{^khanify (.*)}i,                                    :meme_khanify,          help: { "khanify ..." => "generates khan meme" }
       route %r{(so.*|very.*|much.*|such.*) (wow)}i,                                       :meme_doge,             help: { "so|very|much|such... wow" => "generates doge meme" }
       route %r{(Imma let you finish) (.*)}i,                       :meme_kanye,            help: { "Imma let you finish ..." => "generates kanye meme"}

--- a/lib/lita/handlers/memegen.rb
+++ b/lib/lita/handlers/memegen.rb
@@ -10,29 +10,29 @@ module Lita
         config.password = nil
       end
 
-      route %r{(y u no) (.+)}i,                                    :meme_y_u_no,           help: { "y u no..." => "generates Y U NO meme"}
-      route %r{(i don'?t always .*) (but when i do,? .*)}i,        :meme_i_dont_always,    help: { "i don't always... but when i do,..." => "generates I DON'T ALWAYS meme"}
-      route %r{(.*)(o\s?rly\??.*)}i,                               :meme_orly,             help: { "...o rly..." => "generates O RLY meme" }
-      route %r{(.*)(SUCCESS|NAILED IT.*)},                         :meme_success,          help: { "...SUCCESS" => "(case sensitive) generates SUCCESS meme", "...NAILED IT..." => "(case sensitive) generates NAILED IT meme" }
-      route %r{(.*) (ALL the .*)},                                 :meme_all_the,          help: { "...ALL the..." => "(case sensitive) generates ALL the <things> meme" }
-      route %r{(.*) (\w+\stoo damn .*)}i,                          :meme_too_damn,         help: { "...too damn..." => "generates TOO DAMN meme" }
-      route %r{(good news everyone[,.!]?) (.*)}i,                  :meme_good_news,        help: { "good news everyone..." => "generates GOOD NEWS EVERYONE meme" }
-      route %r{(not sure if .*) (or .*)}i,                         :meme_not_sure_if,      help: { "not sure if... or..." => "generates NOT SURE IF... OR meme" }
-      route %r{(yo dawg .*) (so .*)}i,                             :meme_yo_dawg,          help: { "yo dawg... so..." => "generates YO DAWG meme" }
-      route %r{(all your .*) (are belong to us)}i,                 :meme_are_belong,       help: { "all your... are belong to us" => "generates ALL YOUR... ARE BELONG TO US meme" }
-      route %r{(.*) (fuck you)$}i,                                 :meme_fuck_you,         help: { "...fuck you" => "generates ...FUCK YOU meme" }
-      route %r{(.*) (you'?re gonna have a bad time)}i,             :meme_bad_time,         help: { "...you're going have a bad time" => "generates You're gonna have a bad time meme" }
-      route %r{(one does not simply) (.*)}i,                       :meme_simply,           help: { "one does not simply..." => "generates one does not simply... meme" }
-      route %r{(grumpy cat) (.*),(.*)}i,                           :meme_grumpy_cat,       help: { "grumpy cat... ,..." => "generates grumpy cat... ,... meme" }
-      route %r{(it looks like you'?re|it looks like you) (.*)}i,   :meme_looks_like,       help: { "it looks like you're..." => "generates it looks like you're... meme", "it looks like you..." => "(case insensitive) generates it looks like you.. meme" }
-      route %r{(am i the only one around here) (.*)}i,             :meme_am_i_only,        help: { "am I the only one around here..." => "generates AM I THE ONLY ONE AROUND HERE... meme" }
-      route %r{(.*)(not impressed*)}i,                             :meme_not_impressed,    help: { "...not impressed" => "generates ...NOT IMPRESSED meme" }
-      route %r{(prepare yourself) (.*)}i,                          :meme_prepare_yourself, help: { "prepare yourself..." => "generates PREPARE YOURSELF... meme" }
-      route %r{(what if i told you) (.*)}i,                        :meme_what_if_i,        help: { "what if I told you..." => "generates WHAT IF I TOLD YOU... meme" }
-      route %r{(.*) (better drink my own piss)}i,                  :meme_better_drink,     help: { "..better drink my own piss" => "generates ...BETTER DRINK MY OWN PISS meme" }
-      route %r{^khanify (.*)}i,                                    :meme_khanify,          help: { "khanify ..." => "generates khan meme" }
-      route %r{(imma let you finish) (.*)}i,                       :meme_kanye,            help: { "imma let you finish ..." => "generates kanye meme" }
+      route %r{(y u no) (.+)}i,                                         :meme_y_u_no,           help: { "y u no..." => "generates Y U NO meme"}
+      route %r{(i don'?t always .*) (but when i do,? .*)}i,             :meme_i_dont_always,    help: { "i don't always... but when i do,..." => "generates I DON'T ALWAYS meme"}
+      route %r{(.*)(o\s?rly\??.*)}i,                                    :meme_orly,             help: { "...o rly..." => "generates O RLY meme" }
+      route %r{(.*)(SUCCESS|NAILED IT.*)},                              :meme_success,          help: { "...SUCCESS" => "(case sensitive) generates SUCCESS meme", "...NAILED IT..." => "(case sensitive) generates NAILED IT meme" }
+      route %r{(.*) (ALL the .*)},                                      :meme_all_the,          help: { "...ALL the..." => "(case sensitive) generates ALL the <things> meme" }
+      route %r{(.*) (\w+\stoo damn .*)}i,                               :meme_too_damn,         help: { "...too damn..." => "generates TOO DAMN meme" }
+      route %r{(good news everyone[,.!]?) (.*)}i,                       :meme_good_news,        help: { "good news everyone..." => "generates GOOD NEWS EVERYONE meme" }
+      route %r{(not sure if .*) (or .*)}i,                              :meme_not_sure_if,      help: { "not sure if... or..." => "generates NOT SURE IF... OR meme" }
+      route %r{(yo dawg .*) (so .*)}i,                                  :meme_yo_dawg,          help: { "yo dawg... so..." => "generates YO DAWG meme" }
+      route %r{(all your .*) (are belong to us)}i,                      :meme_are_belong,       help: { "all your... are belong to us" => "generates ALL YOUR... ARE BELONG TO US meme" }
+      route %r{(.*) (fuck you)$}i,                                      :meme_fuck_you,         help: { "...fuck you" => "generates ...FUCK YOU meme" }
+      route %r{(.*) (you'?re gonna have a bad time)}i,                  :meme_bad_time,         help: { "...you're going have a bad time" => "generates You're gonna have a bad time meme" }
+      route %r{(one does not simply) (.*)}i,                            :meme_simply,           help: { "one does not simply..." => "generates one does not simply... meme" }
+      route %r{(grumpy cat) (.*),(.*)}i,                                :meme_grumpy_cat,       help: { "grumpy cat... ,..." => "generates grumpy cat... ,... meme" }
+      route %r{(it looks like you'?re|it looks like you) (.*)}i,        :meme_looks_like,       help: { "it looks like you're..." => "generates it looks like you're... meme", "it looks like you..." => "(case insensitive) generates it looks like you.. meme" }
+      route %r{(am i the only one around here) (.*)}i,                  :meme_am_i_only,        help: { "am I the only one around here..." => "generates AM I THE ONLY ONE AROUND HERE... meme" }
+      route %r{(.*)(not impressed*)}i,                                  :meme_not_impressed,    help: { "...not impressed" => "generates ...NOT IMPRESSED meme" }
+      route %r{(prepare yourself) (.*)}i,                               :meme_prepare_yourself, help: { "prepare yourself..." => "generates PREPARE YOURSELF... meme" }
+      route %r{(what if i told you) (.*)}i,                             :meme_what_if_i,        help: { "what if I told you..." => "generates WHAT IF I TOLD YOU... meme" }
+      route %r{(.*) (better drink my own piss)}i,                       :meme_better_drink,     help: { "..better drink my own piss" => "generates ...BETTER DRINK MY OWN PISS meme" }
+      route %r{^khanify (.*)}i,                                         :meme_khanify,          help: { "khanify ..." => "generates khan meme" }
       route %r{(so|very|much|such) (.*) (so|very|much|such) (.*) wow}i, :meme_doge,             help: { "so|very|much|such... so|very|much|such... wow" => "generates doge meme" }
+      route %r{(imma let you finish) (.*)}i,                            :meme_kanye,            help: { "imma let you finish ..." => "generates kanye meme" }
 
 
       def meme_y_u_no(response)

--- a/lib/lita/handlers/memegen.rb
+++ b/lib/lita/handlers/memegen.rb
@@ -32,7 +32,7 @@ module Lita
       route %r{(.*) (better drink my own piss)}i,                  :meme_better_drink,     help: { "..better drink my own piss" => "generates ...BETTER DRINK MY OWN PISS meme" }
       route %r{^khanify (.*)}i,                                    :meme_khanify,          help: { "khanify ..." => "generates khan meme" }
       route %r{(so.*|very.*|much.*|such.*) (wow)}i,                                       :meme_doge,             help: { "so|very|much|such... wow" => "generates doge meme" }
-      route %r{(Imma let you finish) (.*)}i,                       :meme_kanye,            help: { "Imma let you finish ..." => "generates kanye meme"}
+      route %r{(imma let you finish) (.*)}i,                       :meme_kanye,            help: { "imma let you finish ..." => "generates kanye meme" }
 
 
       def meme_y_u_no(response)
@@ -139,7 +139,6 @@ module Lita
       def generate_meme *args
         MemeGenerator.generate_meme *args
       end
-
     end
 
     Lita.register_handler(Memegen)

--- a/lib/lita/handlers/memegen.rb
+++ b/lib/lita/handlers/memegen.rb
@@ -31,7 +31,7 @@ module Lita
       route %r{(what if i told you) (.*)}i,                        :meme_what_if_i,        help: { "what if I told you..." => "generates WHAT IF I TOLD YOU... meme" }
       route %r{(.*) (better drink my own piss)}i,                  :meme_better_drink,     help: { "..better drink my own piss" => "generates ...BETTER DRINK MY OWN PISS meme" }
       route %r{^khanify (.*)}i,                                    :meme_khanify,          help: { "khanify ..." => "generates khan meme" }
-      route %r{(so.*|very.*|much.*|such.*) (wow)}i,                                       :meme_doge,             help: { "so|very|much|such... wow" => "generates doge meme" }
+      route %r{(so|very|much|such) (.*) wow}i,                     :meme_doge,             help: { "so|very|much|such... wow" => "generates doge meme" }
       route %r{(imma let you finish) (.*)}i,                       :meme_kanye,            help: { "imma let you finish ..." => "generates kanye meme" }
 
 
@@ -127,7 +127,7 @@ module Lita
       end
 
       def meme_doge(response)
-        generate_meme(response, 2452817, 9861901)
+        generate_meme(response, 2452817, 9861901, line1: "#{response.matches[0][0]} #{response.matches[0][1]}", line2: 'wow')
       end
 
       def meme_kanye(response)

--- a/lib/lita/handlers/memegen.rb
+++ b/lib/lita/handlers/memegen.rb
@@ -31,8 +31,8 @@ module Lita
       route %r{(what if i told you) (.*)}i,                        :meme_what_if_i,        help: { "what if I told you..." => "generates WHAT IF I TOLD YOU... meme" }
       route %r{(.*) (better drink my own piss)}i,                  :meme_better_drink,     help: { "..better drink my own piss" => "generates ...BETTER DRINK MY OWN PISS meme" }
       route %r{^khanify (.*)}i,                                    :meme_khanify,          help: { "khanify ..." => "generates khan meme" }
-      route %r{(so|very|much|such) (.*) wow}i,                     :meme_doge,             help: { "so|very|much|such... wow" => "generates doge meme" }
       route %r{(imma let you finish) (.*)}i,                       :meme_kanye,            help: { "imma let you finish ..." => "generates kanye meme" }
+      route %r{(so|very|much|such) (.*) (so|very|much|such) (.*) wow}i, :meme_doge,             help: { "so|very|much|such... so|very|much|such... wow" => "generates doge meme" }
 
 
       def meme_y_u_no(response)
@@ -127,7 +127,9 @@ module Lita
       end
 
       def meme_doge(response)
-        generate_meme(response, 2452817, 9861901, line1: "#{response.matches[0][0]} #{response.matches[0][1]}", line2: 'wow')
+        doge1, text1, doge2, text2 = *response.matches.first
+        generate_meme(response, 2452817, 9861901, line1: "#{doge1} #{text1}",
+                                                  line2: "#{doge2} #{text2} wow")
       end
 
       def meme_kanye(response)

--- a/lib/lita/handlers/memegen.rb
+++ b/lib/lita/handlers/memegen.rb
@@ -20,7 +20,7 @@ module Lita
       route %r{(not sure if .*) (or .*)}i,                         :meme_not_sure_if,      help: { "not sure if... or..." => "generates NOT SURE IF... OR meme" }
       route %r{(yo dawg .*) (so .*)}i,                             :meme_yo_dawg,          help: { "yo dawg... so..." => "generates YO DAWG meme" }
       route %r{(all your .*) (are belong to us)}i,                 :meme_are_belong,       help: { "all your... are belong to us" => "generates ALL YOUR... ARE BELONG TO US meme" }
-      route %r{(.*) (fuck you)}i,                                  :meme_fuck_you,         help: { "...fuck you" => "generates ...FUCK YOU meme" }
+      route %r{(.*) (fuck you)$}i,                                 :meme_fuck_you,         help: { "...fuck you" => "generates ...FUCK YOU meme" }
       route %r{(.*) (you'?re gonna have a bad time)}i,             :meme_bad_time,         help: { "...you're going have a bad time" => "generates You're gonna have a bad time meme" }
       route %r{(one does not simply) (.*)}i,                       :meme_simply,           help: { "one does not simply..." => "generates one does not simply... meme" }
       route %r{(grumpy cat) (.*),(.*)}i,                           :meme_grumpy_cat,       help: { "grumpy cat... ,..." => "generates grumpy cat... ,... meme" }

--- a/spec/lita/handlers/memegen_spec.rb
+++ b/spec/lita/handlers/memegen_spec.rb
@@ -32,7 +32,7 @@ describe Lita::Handlers::Memegen, lita_handler: true do
       meme_what_if_i: ["what if i told you blah"],
       meme_better_drink: ["blah better drink my own piss"],
       meme_khanify: ["khanify blah"],
-      meme_doge: ["such blah wow"],
+      meme_doge: ["such blah much wat wow"],
       meme_kanye: ["imma let you finish blah"]
     }
 
@@ -210,9 +210,9 @@ describe Lita::Handlers::Memegen, lita_handler: true do
     end
 
     describe '#meme_doge' do
-      let(:response) { double matches: [['such', 'text']] }
+      let(:response) { double matches: [['such', 'text', 'much', 'other']] }
       it 'calls #generate_meme with the correct arguments' do
-        expect(MemeGenerator).to receive(:generate_meme).with response, 2452817, 9861901, line1: 'such text', line2: 'wow'
+        expect(MemeGenerator).to receive(:generate_meme).with response, 2452817, 9861901, line1: 'such text', line2: 'much other wow'
         subject.meme_doge response
       end
     end

--- a/spec/lita/handlers/memegen_spec.rb
+++ b/spec/lita/handlers/memegen_spec.rb
@@ -210,8 +210,9 @@ describe Lita::Handlers::Memegen, lita_handler: true do
     end
 
     describe '#meme_doge' do
+      let(:response) { double matches: [['such', 'text']] }
       it 'calls #generate_meme with the correct arguments' do
-        expect(MemeGenerator).to receive(:generate_meme).with response, 2452817, 9861901
+        expect(MemeGenerator).to receive(:generate_meme).with response, 2452817, 9861901, line1: 'such text', line2: 'wow'
         subject.meme_doge response
       end
     end


### PR DESCRIPTION
- fixes "fuck you" meme regex
  - will now only activate when the phrase ends with "fuck you"
- fixes doge meme regex
  - now needs at least 2 doges to doge
- fixes docs in README
- fixes some whitespace
- adds some parens for consistency
- cleans up help tags and route regexes
  - lowercases help text that is case insensitive
  - fixes some inconsistencies in the help text
- updates specs to reflect changes
